### PR TITLE
Support KeyValue in native tables

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/impl/PulsarCatalogSupport.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/impl/PulsarCatalogSupport.java
@@ -24,7 +24,9 @@ import org.apache.flink.connector.pulsar.table.PulsarTableFactory;
 import org.apache.flink.connector.pulsar.table.PulsarTableOptions;
 import org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogConfiguration;
 import org.apache.flink.connector.pulsar.table.catalog.utils.TableSchemaHelper;
+import org.apache.flink.formats.avro.AvroFormatFactory;
 import org.apache.flink.formats.raw.RawFormatFactory;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
@@ -35,10 +37,13 @@ import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.factories.FactoryUtil;
 
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.connector.pulsar.table.PulsarTableOptions.VALUE_FORMAT;
 
@@ -65,6 +71,7 @@ public class PulsarCatalogSupport {
             "__database_detailed_description";
 
     private static final String TABLE_PREFIX = "table_";
+    private static final String KEY_PREFIX = "key.";
 
     PulsarCatalogConfiguration catalogConfiguration;
 
@@ -268,12 +275,54 @@ public class PulsarCatalogSupport {
     }
 
     private CatalogTable schemaToCatalogTable(SchemaInfo pulsarSchema, String topicName) {
-        final Schema schema = schemaTranslator.pulsarSchemaToFlinkSchema(pulsarSchema);
-
         Map<String, String> initialTableOptions = new HashMap<>();
         initialTableOptions.put(PulsarTableOptions.TOPICS.key(), topicName);
-        initialTableOptions.put(
-                FactoryUtil.FORMAT.key(), schemaTranslator.decideDefaultFlinkFormat(pulsarSchema));
+
+        Schema schema;
+        if(pulsarSchema.getType() == SchemaType.KEY_VALUE) {
+            KeyValue<SchemaInfo, SchemaInfo> keyValueSchemaInfo =
+                    KeyValueSchemaInfo.decodeKeyValueSchemaInfo(pulsarSchema);
+            SchemaInfo keySchemaInfo = keyValueSchemaInfo.getKey();
+            SchemaInfo valueSchemaInfo = keyValueSchemaInfo.getValue();
+
+            Map<String, DataTypes.Field> valueFields =
+                    schemaTranslator.pulsarSchemaToPhysicalFields(valueSchemaInfo, "kv.value");
+            Map<String, DataTypes.Field> keyFields =
+                    schemaTranslator.pulsarSchemaToPhysicalFields(keySchemaInfo, "kv.key");
+
+            String keyFormat = schemaTranslator.decideDefaultFlinkFormat(keySchemaInfo);
+
+            // Resolve field name conflicts between key and value
+            List<DataTypes.Field> fields = new ArrayList<>();
+            keyFields.forEach((fieldName, fieldValue) -> {
+                if (valueFields.containsKey(fieldName)) {
+                    if (AvroFormatFactory.IDENTIFIER.equals(keyFormat) || RawFormatFactory.IDENTIFIER.equals(keyFormat)) {
+                        fieldName = KEY_PREFIX + fieldName;
+                        fields.add(DataTypes.FIELD(fieldName, fieldValue.getDataType()));
+                    }
+                } else {
+                    fields.add(fieldValue);
+                }
+            });
+
+            initialTableOptions.put(
+                    PulsarTableOptions.KEY_FORMAT.key(), keyFormat);
+            initialTableOptions.put(
+                    FactoryUtil.FORMAT.key(), schemaTranslator.decideDefaultFlinkFormat(valueSchemaInfo));
+
+            String keyFieldsOption = fields.stream()
+                    .map(DataTypes.AbstractField::getName)
+                    .collect(Collectors.joining(";"));
+            initialTableOptions.put(PulsarTableOptions.KEY_FIELDS.key(), keyFieldsOption);
+
+            fields.addAll(valueFields.values());
+            schema = schemaTranslator.fieldsToSchema(fields);
+
+        } else {
+            schema = schemaTranslator.pulsarSchemaToFlinkSchema(pulsarSchema, "value");
+            initialTableOptions.put(
+                    FactoryUtil.FORMAT.key(), schemaTranslator.decideDefaultFlinkFormat(pulsarSchema));
+        }
 
         Map<String, String> enrichedTableOptions =
                 fillDefaultOptionsFromCatalogOptions(initialTableOptions);

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/impl/SchemaTranslator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/impl/SchemaTranslator.java
@@ -24,6 +24,7 @@ import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.formats.json.JsonFormatFactory;
 import org.apache.flink.formats.raw.RawFormatFactory;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.logical.RowType;
@@ -37,7 +38,10 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Translate a Pulsar Schema to Flink Table Schema. */
 public class SchemaTranslator {
@@ -51,23 +55,25 @@ public class SchemaTranslator {
         this.useMetadataFields = useMetadataFields;
     }
 
-    public org.apache.flink.table.api.Schema pulsarSchemaToFlinkSchema(SchemaInfo pulsarSchema)
+    public Schema pulsarSchemaToFlinkSchema(SchemaInfo pulsarSchema,  String singleFieldFieldName)
             throws IncompatibleSchemaException {
-        final DataType fieldsDataType = pulsarSchemaToPhysicalFields(pulsarSchema);
-        org.apache.flink.table.api.Schema.Builder schemaBuilder =
-                org.apache.flink.table.api.Schema.newBuilder().fromRowDataType(fieldsDataType);
+        return fieldsToSchema(pulsarSchemaToPhysicalFields(pulsarSchema, singleFieldFieldName).values());
+    }
+
+    public Schema fieldsToSchema(Collection<DataTypes.Field> fields) {
+        final DataType fieldsDataType = DataTypes.ROW(fields.toArray(new DataTypes.Field[0]));
+        Schema.Builder schemaBuilder = Schema.newBuilder().fromRowDataType(fieldsDataType);
 
         if (useMetadataFields) {
             throw new UnsupportedOperationException(
                     "Querying Pulsar Metadata is not supported yet");
         }
-
         return schemaBuilder.build();
     }
 
-    public DataType pulsarSchemaToPhysicalFields(SchemaInfo schemaInfo)
+    public Map<String, DataTypes.Field> pulsarSchemaToPhysicalFields(SchemaInfo schemaInfo, String singleFieldFieldName)
             throws IncompatibleSchemaException {
-        List<DataTypes.Field> mainSchema = new ArrayList<>();
+        Map<String, DataTypes.Field> mainSchema = new LinkedHashMap<>();
         DataType dataType = schemaInfo2SqlType(schemaInfo);
         // ROW and STRUCTURED are FieldsDataType
         if (dataType instanceof FieldsDataType) {
@@ -76,18 +82,18 @@ public class SchemaTranslator {
             List<String> fieldNames = rowType.getFieldNames();
             for (int i = 0; i < fieldNames.size(); i++) {
                 org.apache.flink.table.types.logical.LogicalType logicalType = rowType.getTypeAt(i);
+                String fieldName = fieldNames.get(i);
                 DataTypes.Field field =
                         DataTypes.FIELD(
-                                fieldNames.get(i),
+                                fieldName,
                                 TypeConversions.fromLogicalToDataType(logicalType));
-                mainSchema.add(field);
+                mainSchema.put(fieldName, field);
             }
 
         } else {
-            mainSchema.add(DataTypes.FIELD(SINGLE_FIELD_FIELD_NAME, dataType));
+            mainSchema.put(singleFieldFieldName, DataTypes.FIELD(singleFieldFieldName, dataType));
         }
-
-        return DataTypes.ROW(mainSchema.toArray(new DataTypes.Field[0]));
+        return mainSchema;
     }
 
     public DataType schemaInfo2SqlType(SchemaInfo si) throws IncompatibleSchemaException {

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/impl/SchemaTranslator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/impl/SchemaTranslator.java
@@ -55,9 +55,10 @@ public class SchemaTranslator {
         this.useMetadataFields = useMetadataFields;
     }
 
-    public Schema pulsarSchemaToFlinkSchema(SchemaInfo pulsarSchema,  String singleFieldFieldName)
+    public Schema pulsarSchemaToFlinkSchema(SchemaInfo pulsarSchema, String singleFieldFieldName)
             throws IncompatibleSchemaException {
-        return fieldsToSchema(pulsarSchemaToPhysicalFields(pulsarSchema, singleFieldFieldName).values());
+        return fieldsToSchema(
+                pulsarSchemaToPhysicalFields(pulsarSchema, singleFieldFieldName).values());
     }
 
     public Schema fieldsToSchema(Collection<DataTypes.Field> fields) {
@@ -71,8 +72,8 @@ public class SchemaTranslator {
         return schemaBuilder.build();
     }
 
-    public Map<String, DataTypes.Field> pulsarSchemaToPhysicalFields(SchemaInfo schemaInfo, String singleFieldFieldName)
-            throws IncompatibleSchemaException {
+    public Map<String, DataTypes.Field> pulsarSchemaToPhysicalFields(
+            SchemaInfo schemaInfo, String singleFieldFieldName) throws IncompatibleSchemaException {
         Map<String, DataTypes.Field> mainSchema = new LinkedHashMap<>();
         DataType dataType = schemaInfo2SqlType(schemaInfo);
         // ROW and STRUCTURED are FieldsDataType
@@ -85,8 +86,7 @@ public class SchemaTranslator {
                 String fieldName = fieldNames.get(i);
                 DataTypes.Field field =
                         DataTypes.FIELD(
-                                fieldName,
-                                TypeConversions.fromLogicalToDataType(logicalType));
+                                fieldName, TypeConversions.fromLogicalToDataType(logicalType));
                 mainSchema.put(fieldName, field);
             }
 

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalogITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalogITCase.java
@@ -31,8 +31,11 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.shade.org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -768,6 +771,64 @@ public class PulsarCatalogITCase extends PulsarTableTestBase {
                             .map(Message::getValue)
                             .collect(Collectors.toList());
             assertThat(result).containsExactlyElementsOf(INTEGER_LIST);
+        }
+
+        @Test
+        void readFromNativeTableWithKeyValueAvroSchema() throws Exception {
+            String topicName = newTopicName();
+            Schema<TestingUser> schema = Schema.AVRO(TestingUser.class);
+            KeyValue<TestingUser, TestingUser> expectedUser =
+                    new KeyValue<>(createRandomUser(), createRandomUser());
+            Schema<KeyValue<TestingUser, TestingUser>> keyValueSchema =
+                    KeyValueSchemaImpl.of(schema, schema, KeyValueEncodingType.SEPARATED);
+
+            pulsar.operator().sendMessage(topicName, keyValueSchema, expectedUser);
+
+            tableEnv.useCatalog(PULSAR_CATALOG1);
+            tableEnv.useDatabase(PULSAR1_DB);
+
+            final List<Row> result =
+                    collectRows(
+                            tableEnv.sqlQuery(
+                                    String.format(
+                                            "select age, name, `key.age`, `key.name` from %s",
+                                            TopicName.get(topicName).getLocalName())),
+                            1);
+            assertThat(result)
+                    .containsExactlyElementsOf(
+                            Collections.singletonList(
+                                    Row.of(
+                                            expectedUser.getValue().getAge(),
+                                            expectedUser.getValue().getName(),
+                                            expectedUser.getKey().getAge(),
+                                            expectedUser.getKey().getName())));
+        }
+
+        @Test
+        void readFromNativeTableWithKeyValuePrimitiveSchema() throws Exception {
+            String topicName = newTopicName();
+            String expectedString = "expected_string";
+            Integer expectedInteger = 42;
+            KeyValue<String, Integer> message = new KeyValue<>(expectedString, expectedInteger);
+            Schema<KeyValue<String, Integer>> keyValueSchema =
+                    KeyValueSchemaImpl.of(
+                            Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+            pulsar.operator().sendMessage(topicName, keyValueSchema, message);
+
+            tableEnv.useCatalog(PULSAR_CATALOG1);
+            tableEnv.useDatabase(PULSAR1_DB);
+
+            final List<Row> result =
+                    collectRows(
+                            tableEnv.sqlQuery(
+                                    String.format(
+                                            "select `kv.key`, `kv.value` from %s",
+                                            TopicName.get(topicName).getLocalName())),
+                            1);
+            assertThat(result)
+                    .containsExactlyElementsOf(
+                            Collections.singletonList(Row.of(expectedString, expectedInteger)));
         }
 
         @ParameterizedTest


### PR DESCRIPTION
The mapping rules are:
* Primitive keys are mapped to `key`
* Primitive values are mapped to `value`
* AVRO/JSON fields are mapped to the column with the same name.
* For AVRO, if a key field has the same name as a value field, the column name for the key is the field name prefixed by `__key_`
* For KV<primitive, struct> types, if the value has a `key` field, the column name for the primitive key is `__key_key`